### PR TITLE
Fix: march issue fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-DOCKERFILES = ./nginx/Dockerfile					\
-			  			./users-service/Dockerfile
+SERVICE_DIRS := $(shell find . -maxdepth 1 -type d -name '*-service' -o -name 'nginx' -o -name 'redis' -o -name 'game' -o -name 'jwt' -o -name 'blockchain' -o -name 'presences' -o -name 'avatars' -o -name 'friends')
+SERVICE_SRC := $(shell find $(SERVICE_DIRS) -type f \( -name '*.js' -o -name '*.ts' -o -name '*.json' -o -name '*.sol' \))
 
-start: images
+start: .images
 	@docker compose -f ./docker-compose.yml up -d
 
-images: $(DOCKERFILES)
+.images: $(SERVICE_SRC)
 	@COMPOSE_BAKE=true docker compose -f ./docker-compose.yml build
 	@touch .images
 
@@ -19,4 +19,4 @@ clean: stop
 
 re: clean start
 
-.PHONY: start images stop restart clean re
+.PHONY: start stop images restart clean re


### PR DESCRIPTION
'images' was pointing to nothing existing. Replaced by '.images' on both start and images rules.
The makefile wasn't checking files properly. SERVICE_DIRS and SERVICE_SRC check definition variables added.
The old DOCKERFILES definition was no longer relevant, removed.