### PR TITLE
Add independant rebuild targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+
+
 start: images
 	@docker compose -f ./docker-compose.yml up -d
 
-images: $(DOCKERFILES)
+images:
 	@COMPOSE_BAKE=true docker compose -f ./docker-compose.yml build
 	@touch .images
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMPOSE_FILE = ./docker-compose.yml
-DOCKER_COMPOSE = docker compose -f $(COMPOSE_FILE)
+DOCKER_COMPOSE = COMPOSE_BAKE=true  docker compose -f $(COMPOSE_FILE)
 
 start:
 	@$(DOCKER_COMPOSE) up -d
@@ -10,14 +10,43 @@ stop:
 restart: stop start
 
 build:
-	@COMPOSE_BAKE=true $(DOCKER_COMPOSE) build
+	@$(DOCKER_COMPOSE) build
 
 rebuild-%:
 	@$(DOCKER_COMPOSE) up -d --build $*
 
+rebuild-nginx:
+	@$(DOCKER_COMPOSE) up -d --build nginx
+
+rebuild-users:
+	@$(DOCKER_COMPOSE) up -d --build users
+
+rebuild-jwt:
+	@$(DOCKER_COMPOSE) up -d --build jwt
+
+rebuild-redis:
+	@$(DOCKER_COMPOSE) up -d --build redis
+
+rebuild-game:
+	@$(DOCKER_COMPOSE) up -d --build game
+
+rebuild-blockchain:
+	@$(DOCKER_COMPOSE) up -d --build blockchain
+
+rebuild-avatars:
+	@$(DOCKER_COMPOSE) up -d --build avatars
+
+rebuild-friends:
+	@$(DOCKER_COMPOSE) up -d --build friends
+
+rebuild-presences:
+	@$(DOCKER_COMPOSE) up -d --build presences
+		
 clean: stop
-	@docker system prune -af
-	@rm -f .images
+	@$(DOCKER_COMPOSE) down --remove-orphans
+
+clean-images: clean
+	@$(DOCKER_COMPOSE) down --rmi local
 
 re: clean start
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-DOCKERFILES = ./nginx/Dockerfile					\
-			  			./users-service/Dockerfile
-
 start: images
 	@docker compose -f ./docker-compose.yml up -d
 

--- a/Makefile
+++ b/Makefile
@@ -12,32 +12,8 @@ restart: stop start
 build:
 	@COMPOSE_BAKE=true $(DOCKER_COMPOSE) build
 
-rebuild-nginx:
-	@$(DOCKER_COMPOSE) up -d --build nginx
-
-rebuild-redis:
-	@$(DOCKER_COMPOSE) up -d --build redis
-
-rebuild-users:
-	@$(DOCKER_COMPOSE) up -d --build users
-
-rebuild-jwt:
-	@$(DOCKER_COMPOSE) up -d --build jwt
-
-rebuild-blockchain:
-	@$(DOCKER_COMPOSE) up -d --build blockchain
-
-rebuild-game:
-	@$(DOCKER_COMPOSE) up -d --build game
-
-rebuild-avatars:
-	@$(DOCKER_COMPOSE) up -d --build avatars
-
-rebuild-friends:
-	@$(DOCKER_COMPOSE) up -d --build friends
-
-rebuild-presences:
-	@$(DOCKER_COMPOSE) up -d --build presences
+rebuild-%:
+	@$(DOCKER_COMPOSE) up -d --build $*
 
 clean: stop
 	@docker system prune -af

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,43 @@
+COMPOSE_FILE = ./docker-compose.yml
+DOCKER_COMPOSE = docker compose -f $(COMPOSE_FILE)
 
-
-start: images
-	@docker compose -f ./docker-compose.yml up -d
-
-images:
-	@COMPOSE_BAKE=true docker compose -f ./docker-compose.yml build
-	@touch .images
+start:
+	@$(DOCKER_COMPOSE) up -d
 
 stop:
-	@docker compose -f ./docker-compose.yml down
+	@$(DOCKER_COMPOSE) down
 
 restart: stop start
+
+build:
+	@COMPOSE_BAKE=true $(DOCKER_COMPOSE) build
+
+rebuild-nginx:
+	@$(DOCKER_COMPOSE) up -d --build nginx
+
+rebuild-redis:
+	@$(DOCKER_COMPOSE) up -d --build redis
+
+rebuild-users:
+	@$(DOCKER_COMPOSE) up -d --build users
+
+rebuild-jwt:
+	@$(DOCKER_COMPOSE) up -d --build jwt
+
+rebuild-blockchain:
+	@$(DOCKER_COMPOSE) up -d --build blockchain
+
+rebuild-game:
+	@$(DOCKER_COMPOSE) up -d --build game
+
+rebuild-avatars:
+	@$(DOCKER_COMPOSE) up -d --build avatars
+
+rebuild-friends:
+	@$(DOCKER_COMPOSE) up -d --build friends
+
+rebuild-presences:
+	@$(DOCKER_COMPOSE) up -d --build presences
 
 clean: stop
 	@docker system prune -af


### PR DESCRIPTION
This pull request refactors the `Makefile` to streamline Docker Compose commands and improve maintainability. The changes introduce a new variable for the Docker Compose file, simplify commonly used commands, and add specific rebuild targets for individual services.

### Refactoring and simplification of Docker Compose commands:

* Removed the `DOCKERFILES` variable and replaced it with `COMPOSE_FILE` and `DOCKER_COMPOSE` variables to centralize and simplify Docker Compose command definitions.
* Simplified the `start` and `stop` targets by replacing explicit Docker Compose commands with the new `DOCKER_COMPOSE` variable.

### New rebuild targets for individual services:

* Added `rebuild-*` targets (e.g., `rebuild-nginx`, `rebuild-users`, etc.) to allow rebuilding and restarting specific services individually.

### Enhancements to cleaning commands:

* Updated the `clean` target to use `down --remove-orphans` for better cleanup of orphaned containers.
* Added a `clean-images` target to remove local images using `down --rmi local`.